### PR TITLE
Add missing yargs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "epicfail": "^3.0.0",
     "masterchat": "^0.11.0",
-    "vm2": "^3.9.3"
+    "vm2": "^3.9.3",
+    "yargs": "^17.2.1"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",


### PR DESCRIPTION
Closes #1 

It seems with very fresh Node installations, `yards` has to be specified as a dependency explicitly.